### PR TITLE
fix(structure): remove unrequired meta file for missing directory

### DIFF
--- a/Runtime/SharedResources/NestedPrefabs.meta
+++ b/Runtime/SharedResources/NestedPrefabs.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 64161e978ebd2334681b59667aa63b4b
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
The NestedPrefabs directory isn't required so therefore was never
committed, however the .meta file still was checked in which is
incorrect so it has now been deleted.