### PR TITLE
fix(Interactables): update Interactables namespace to latest

### DIFF
--- a/Runtime/SharedResources/Scripts/ClimbableConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/ClimbableConfigurator.cs
@@ -2,7 +2,7 @@
 {
     using Malimbe.PropertySerializationAttribute;
     using Malimbe.XmlDocumentationAttribute;
-    using Tilia.Interactions.Interactables;
+    using Tilia.Interactions.Interactables.Interactables;
     using UnityEngine;
     using Zinnia.Data.Attribute;
     using Zinnia.Event.Proxy;

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     },
     "dependencies": {
         "io.extendreality.zinnia.unity": "1.19.0",
-        "io.extendreality.tilia.trackers.pseudobody.unity": "1.0.20",
-        "io.extendreality.tilia.interactions.interactables.unity": "1.8.1"
+        "io.extendreality.tilia.trackers.pseudobody.unity": "1.0.21",
+        "io.extendreality.tilia.interactions.interactables.unity": "1.9.0"
     },
     "files": [
         "*.md",


### PR DESCRIPTION
The Interactables namespace changed in version 1.9.0 of the
Interactables package, so it has been updated accordingly.