### PR TITLE
feat(ClimbableFacade): change release multiplier by UnityEvent

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -4,7 +4,6 @@ update_configs:
     directory: /
     update_schedule: live
     default_reviewers:
-      - bddckr
       - thestonefox
     default_labels:
       - dependency-update

--- a/Documentation/API/ClimbableFacade.md
+++ b/Documentation/API/ClimbableFacade.md
@@ -11,6 +11,10 @@ The public interface for the Interactions.Climbable prefab.
   * [ClimbingFacade]
   * [Configuration]
   * [ReleaseMultiplier]
+* [Methods]
+  * [SetReleaseMultiplierX(Single)]
+  * [SetReleaseMultiplierY(Single)]
+  * [SetReleaseMultiplierZ(Single)]
 
 ## Details
 
@@ -61,10 +65,63 @@ The multiplier to apply to the velocity of the interactor when the interactable 
 public Vector3 ReleaseMultiplier { get; set; }
 ```
 
+### Methods
+
+#### SetReleaseMultiplierX(Single)
+
+Sets the [ReleaseMultiplier] x value.
+
+##### Declaration
+
+```
+public virtual void SetReleaseMultiplierX(float value)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | value | The value to set to. |
+
+#### SetReleaseMultiplierY(Single)
+
+Sets the [ReleaseMultiplier] y value.
+
+##### Declaration
+
+```
+public virtual void SetReleaseMultiplierY(float value)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | value | The value to set to. |
+
+#### SetReleaseMultiplierZ(Single)
+
+Sets the [ReleaseMultiplier] z value.
+
+##### Declaration
+
+```
+public virtual void SetReleaseMultiplierZ(float value)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | value | The value to set to. |
+
 [Tilia.Locomotors.Climbing]: README.md
 [ClimbingFacade]: ClimbableFacade.md#ClimbingFacade
 [ClimbingFacade]: ClimbingFacade.md
 [ClimbableConfigurator]: ClimbableConfigurator.md
+[ReleaseMultiplier]: ClimbableFacade.md#ReleaseMultiplier
+[ReleaseMultiplier]: ClimbableFacade.md#ReleaseMultiplier
+[ReleaseMultiplier]: ClimbableFacade.md#ReleaseMultiplier
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
 [Syntax]: #Syntax
@@ -72,3 +129,7 @@ public Vector3 ReleaseMultiplier { get; set; }
 [ClimbingFacade]: #ClimbingFacade
 [Configuration]: #Configuration
 [ReleaseMultiplier]: #ReleaseMultiplier
+[Methods]: #Methods
+[SetReleaseMultiplierX(Single)]: #SetReleaseMultiplierXSingle
+[SetReleaseMultiplierY(Single)]: #SetReleaseMultiplierYSingle
+[SetReleaseMultiplierZ(Single)]: #SetReleaseMultiplierZSingle

--- a/Runtime/SharedResources/Scripts/ClimbableFacade.cs
+++ b/Runtime/SharedResources/Scripts/ClimbableFacade.cs
@@ -33,5 +33,32 @@
         [field: Header("Reference Settings"), DocumentedByXml, Restricted]
         public ClimbableConfigurator Configuration { get; protected set; }
         #endregion
+
+        /// <summary>
+        /// Sets the <see cref="ReleaseMultiplier"/> x value.
+        /// </summary>
+        /// <param name="value">The value to set to.</param>
+        public virtual void SetReleaseMultiplierX(float value)
+        {
+            ReleaseMultiplier = new Vector3(value, ReleaseMultiplier.y, ReleaseMultiplier.z);
+        }
+
+        /// <summary>
+        /// Sets the <see cref="ReleaseMultiplier"/> y value.
+        /// </summary>
+        /// <param name="value">The value to set to.</param>
+        public virtual void SetReleaseMultiplierY(float value)
+        {
+            ReleaseMultiplier = new Vector3(ReleaseMultiplier.x, value, ReleaseMultiplier.z);
+        }
+
+        /// <summary>
+        /// Sets the <see cref="ReleaseMultiplier"/> z value.
+        /// </summary>
+        /// <param name="value">The value to set to.</param>
+        public virtual void SetReleaseMultiplierZ(float value)
+        {
+            ReleaseMultiplier = new Vector3(ReleaseMultiplier.x, ReleaseMultiplier.y, value);
+        }
     }
 }


### PR DESCRIPTION
The ReleaseMultiplier can now be changed by UnityEvents by calling
the relevant component set method:

* SetReleaseMultiplierX
* SetReleaseMultiplierY
* SetReleaseMultiplierZ

As these just take a float then it will show up in the UnityEvent
inspector window.