### PR TITLE
fix(Facade): move deprecated setting to bottom of references

### DIFF
--- a/Documentation/API/ClimbableConfigurator.md
+++ b/Documentation/API/ClimbableConfigurator.md
@@ -44,7 +44,7 @@ The public interface facade.
 ##### Declaration
 
 ```
-public ClimbableFacade Facade { get; protected set; }
+public ClimbableFacade Facade { get; set; }
 ```
 
 #### InteractableFacade
@@ -54,7 +54,7 @@ The [InteractableFacade] component acting as the interactable for climbing.
 ##### Declaration
 
 ```
-public InteractableFacade InteractableFacade { get; protected set; }
+public InteractableFacade InteractableFacade { get; set; }
 ```
 
 #### StartEventProxyEmitter
@@ -64,7 +64,7 @@ The GameObjectEventProxyEmitter component handling a started climb.
 ##### Declaration
 
 ```
-public GameObjectEventProxyEmitter StartEventProxyEmitter { get; protected set; }
+public GameObjectEventProxyEmitter StartEventProxyEmitter { get; set; }
 ```
 
 #### StopEventProxyEmitter
@@ -74,7 +74,7 @@ The GameObjectEventProxyEmitter component handling a stopped climb.
 ##### Declaration
 
 ```
-public GameObjectEventProxyEmitter StopEventProxyEmitter { get; protected set; }
+public GameObjectEventProxyEmitter StopEventProxyEmitter { get; set; }
 ```
 
 ### Methods

--- a/Documentation/API/ClimbableFacade.md
+++ b/Documentation/API/ClimbableFacade.md
@@ -52,7 +52,7 @@ The linked [ClimbableConfigurator].
 ##### Declaration
 
 ```
-public ClimbableConfigurator Configuration { get; protected set; }
+public ClimbableConfigurator Configuration { get; set; }
 ```
 
 #### ReleaseMultiplier

--- a/Documentation/API/ClimbingConfigurator.md
+++ b/Documentation/API/ClimbingConfigurator.md
@@ -55,7 +55,7 @@ The public interface facade.
 ##### Declaration
 
 ```
-public ClimbingFacade Facade { get; protected set; }
+public ClimbingFacade Facade { get; set; }
 ```
 
 #### Interactables
@@ -65,7 +65,7 @@ The objects defining the offsets of movement.
 ##### Declaration
 
 ```
-public GameObjectObservableList Interactables { get; protected set; }
+public GameObjectObservableList Interactables { get; set; }
 ```
 
 #### Interactors
@@ -75,7 +75,7 @@ The objects defining the sources of movement.
 ##### Declaration
 
 ```
-public GameObjectObservableList Interactors { get; protected set; }
+public GameObjectObservableList Interactors { get; set; }
 ```
 
 #### OffsetDistanceComparator
@@ -85,7 +85,7 @@ The ObjectDistanceComparator component for the offset.
 ##### Declaration
 
 ```
-public ObjectDistanceComparator OffsetDistanceComparator { get; protected set; }
+public ObjectDistanceComparator OffsetDistanceComparator { get; set; }
 ```
 
 #### SourceDistanceComparator
@@ -95,7 +95,7 @@ The ObjectDistanceComparator component for the source.
 ##### Declaration
 
 ```
-public ObjectDistanceComparator SourceDistanceComparator { get; protected set; }
+public ObjectDistanceComparator SourceDistanceComparator { get; set; }
 ```
 
 #### TargetPositionProperty
@@ -105,7 +105,7 @@ The TransformPositionMutator component for the offset.
 ##### Declaration
 
 ```
-public TransformPositionMutator TargetPositionProperty { get; protected set; }
+public TransformPositionMutator TargetPositionProperty { get; set; }
 ```
 
 #### VelocityEmitter
@@ -115,7 +115,7 @@ The Zinnia.Tracking.Velocity.VelocityEmitter component for emitting velocity dat
 ##### Declaration
 
 ```
-public VelocityEmitter VelocityEmitter { get; protected set; }
+public VelocityEmitter VelocityEmitter { get; set; }
 ```
 
 #### VelocityMultiplier
@@ -125,7 +125,7 @@ The Vector3Multiplier component for multiplying velocity data.
 ##### Declaration
 
 ```
-public Vector3Multiplier VelocityMultiplier { get; protected set; }
+public Vector3Multiplier VelocityMultiplier { get; set; }
 ```
 
 #### VelocityProxy
@@ -135,7 +135,7 @@ The ComponentTrackerProxy component for obtaining velocity data.
 ##### Declaration
 
 ```
-public ComponentTrackerProxy VelocityProxy { get; protected set; }
+public ComponentTrackerProxy VelocityProxy { get; set; }
 ```
 
 ### Methods

--- a/Documentation/API/ClimbingFacade.md
+++ b/Documentation/API/ClimbingFacade.md
@@ -82,7 +82,7 @@ The linked [ClimbingConfigurator].
 ##### Declaration
 
 ```
-public ClimbingConfigurator Configuration { get; protected set; }
+public ClimbingConfigurator Configuration { get; set; }
 ```
 
 #### CurrentInteractable

--- a/Runtime/SharedResources/Scripts/ClimbableConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/ClimbableConfigurator.cs
@@ -25,7 +25,7 @@
             {
                 return facade;
             }
-            protected set
+            set
             {
                 facade = value;
             }
@@ -47,7 +47,7 @@
             {
                 return interactableFacade;
             }
-            protected set
+            set
             {
                 interactableFacade = value;
             }
@@ -65,7 +65,7 @@
             {
                 return startEventProxyEmitter;
             }
-            protected set
+            set
             {
                 startEventProxyEmitter = value;
             }
@@ -83,7 +83,7 @@
             {
                 return stopEventProxyEmitter;
             }
-            protected set
+            set
             {
                 stopEventProxyEmitter = value;
             }

--- a/Runtime/SharedResources/Scripts/ClimbableFacade.cs
+++ b/Runtime/SharedResources/Scripts/ClimbableFacade.cs
@@ -61,7 +61,7 @@
             {
                 return configuration;
             }
-            protected set
+            set
             {
                 configuration = value;
             }

--- a/Runtime/SharedResources/Scripts/ClimbingConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/ClimbingConfigurator.cs
@@ -30,7 +30,7 @@
             {
                 return facade;
             }
-            protected set
+            set
             {
                 facade = value;
             }
@@ -52,7 +52,7 @@
             {
                 return interactors;
             }
-            protected set
+            set
             {
                 interactors = value;
             }
@@ -70,7 +70,7 @@
             {
                 return interactables;
             }
-            protected set
+            set
             {
                 interactables = value;
             }
@@ -88,7 +88,7 @@
             {
                 return velocityProxy;
             }
-            protected set
+            set
             {
                 velocityProxy = value;
             }
@@ -106,7 +106,7 @@
             {
                 return velocityEmitter;
             }
-            protected set
+            set
             {
                 velocityEmitter = value;
             }
@@ -124,7 +124,7 @@
             {
                 return velocityMultiplier;
             }
-            protected set
+            set
             {
                 velocityMultiplier = value;
             }
@@ -142,7 +142,7 @@
             {
                 return sourceDistanceComparator;
             }
-            protected set
+            set
             {
                 sourceDistanceComparator = value;
             }
@@ -160,7 +160,7 @@
             {
                 return offsetDistanceComparator;
             }
-            protected set
+            set
             {
                 offsetDistanceComparator = value;
             }
@@ -178,7 +178,7 @@
             {
                 return targetPositionProperty;
             }
-            protected set
+            set
             {
                 targetPositionProperty = value;
             }

--- a/Runtime/SharedResources/Scripts/ClimbingFacade.cs
+++ b/Runtime/SharedResources/Scripts/ClimbingFacade.cs
@@ -14,8 +14,67 @@
     /// </summary>
     public class ClimbingFacade : MonoBehaviour
     {
+        #region Climbing Settings
+        [Header("Climbing Settings")]
+        [Tooltip("The target to move when climbing.")]
+        [SerializeField]
+        private ClimbTarget target;
+        /// <summary>
+        /// The target to move when climbing.
+        /// </summary>
+        public ClimbTarget Target
+        {
+            get
+            {
+                return target;
+            }
+            set
+            {
+                target = value;
+                if (this.IsMemberChangeAllowed())
+                {
+                    OnAfterTargetChange();
+                }
+            }
+        }
+        #endregion
+
+        #region Events
+        /// <summary>
+        /// Emitted when a climb starts.
+        /// </summary>
+        [Header("Climbing Events")]
+        public UnityEvent ClimbStarted = new UnityEvent();
+        /// <summary>
+        /// Emitted when the climb stops.
+        /// </summary>
+        public UnityEvent ClimbStopped = new UnityEvent();
+        #endregion
+
+        #region Reference Settings
+        [Header("Reference Settings")]
+        [Tooltip("The linked ClimbingConfigurator.")]
+        [SerializeField]
+        [Restricted]
+        private ClimbingConfigurator configuration;
+        /// <summary>
+        /// The linked <see cref="ClimbingConfigurator"/>.
+        /// </summary>
+        public ClimbingConfigurator Configuration
+        {
+            get
+            {
+                return configuration;
+            }
+            set
+            {
+                configuration = value;
+            }
+        }
+        #endregion
+
 #pragma warning disable 0618
-        #region Control Settings
+        #region Deprecated Settings
         [Tooltip("The body representation to control.")]
         [SerializeField]
         [Restricted]
@@ -42,61 +101,6 @@
         }
         #endregion
 #pragma warning restore 0618
-
-        #region Events
-        /// <summary>
-        /// Emitted when a climb starts.
-        /// </summary>
-        [Header("Events")]
-        public UnityEvent ClimbStarted = new UnityEvent();
-        /// <summary>
-        /// Emitted when the climb stops.
-        /// </summary>
-        public UnityEvent ClimbStopped = new UnityEvent();
-        #endregion
-
-        #region Reference Settings
-        [Header("Reference Settings")]
-        [Tooltip("The target to move when climbing.")]
-        [SerializeField]
-        private ClimbTarget target;
-        /// <summary>
-        /// The target to move when climbing.
-        /// </summary>
-        public ClimbTarget Target
-        {
-            get
-            {
-                return target;
-            }
-            set
-            {
-                target = value;
-                if (this.IsMemberChangeAllowed())
-                {
-                    OnAfterTargetChange();
-                }
-            }
-        }
-        [Tooltip("The linked ClimbingConfigurator.")]
-        [SerializeField]
-        [Restricted]
-        private ClimbingConfigurator configuration;
-        /// <summary>
-        /// The linked <see cref="ClimbingConfigurator"/>.
-        /// </summary>
-        public ClimbingConfigurator Configuration
-        {
-            get
-            {
-                return configuration;
-            }
-            protected set
-            {
-                configuration = value;
-            }
-        }
-        #endregion
 
         /// <summary>
         /// The current source of the movement. The body will be moved in reverse direction in case this object moves.


### PR DESCRIPTION
The PseudoBodyFacade property has been deprecated for some time and the reference to it has now been moved to the bottom of the references so it is clearly out of the way and not the main focus for the Facade settings.

The Climb Target property has been moved to the top, even though it doesn't need setting, this makes it clear that this is a customisable field.

All protected fields have also been made public so they can be set during runtime via code.